### PR TITLE
Add js feature for wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiny_id"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/paulgb/tiny_id"
@@ -9,6 +9,7 @@ description = "Library for generating non-sequential, tightly-packed short IDs. 
 
 [features]
 default = ["getrandom", "serialize"]
+js = ["getrandom/js"]
 serialize = ["rand_chacha/serde1", "rand/serde1", "serde"]
 
 [dependencies]


### PR DESCRIPTION
I want to use this crate in a wasm project. But at the moment I am unable to use it in that project because the underlying `getrandom` crate needs the js feature enabled to be usable in a wasm app. This commit just adds the optional js feature as a pass through feature to `getrandom`. 